### PR TITLE
Changed it so sender and receiver are two different herId

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessor.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessor.kt
@@ -18,7 +18,8 @@ import no.nav.helsemelding.messagegenerator.util.readFileToString
 import org.apache.kafka.clients.producer.RecordMetadata
 import kotlin.uuid.Uuid
 
-const val ADRESSEREGISTERET_HELSEOPPLYSNINGER_TEST1_HERID = "8142519"
+const val FAGSYSTEM_HERID = "8142519"
+const val EPJ_HERID = "8142520"
 val invalidRecordKeys = listOf(null, "", "1234-abcd")
 
 class DialogMessageProcessor(
@@ -38,7 +39,8 @@ class DialogMessageProcessor(
         val params = mapOf(
             "{genDate}" to nowWithOffset(),
             "{messageId}" to uuid.toString(),
-            "{herId}" to ADRESSEREGISTERET_HELSEOPPLYSNINGER_TEST1_HERID,
+            "{senderHerId}" to FAGSYSTEM_HERID,
+            "{receiverHerId}" to EPJ_HERID,
             "{patientName}" to names.random(),
             "{message}" to messages.random()
         )

--- a/src/main/resources/templates/dialogMessage.xml
+++ b/src/main/resources/templates/dialogMessage.xml
@@ -18,7 +18,7 @@
                 <Organisation>
                     <OrganisationName>Samhandling Arbeids- og velferdsetaten</OrganisationName>
                     <Ident>
-                        <Id>{herId}</Id>
+                        <Id>{senderHerId}</Id>
                         <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051"/>
                     </Ident>
                 </Organisation>
@@ -34,7 +34,7 @@
                 <Organisation>
                     <OrganisationName>Samhandling Arbeids- og velferdsetaten</OrganisationName>
                     <Ident>
-                        <Id>{herId}</Id>
+                        <Id>{receiverHerId}</Id>
                         <TypeId V="HER" DN="HER-id" S="2.16.578.1.12.4.1.1.9051"/>
                     </Ident>
                 </Organisation>

--- a/src/test/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessorSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessorSpec.kt
@@ -19,7 +19,8 @@ class DialogMessageProcessorSpec : StringSpec(
 
             xml shouldContain "{genDate}"
             xml shouldContain "{messageId}"
-            xml shouldContain "{herId}"
+            xml shouldContain "{senderHerId}"
+            xml shouldContain "{receiverHerId}"
             xml shouldContain "{patientName}"
             xml shouldContain "{message}"
 
@@ -31,7 +32,8 @@ class DialogMessageProcessorSpec : StringSpec(
             val myMap = mapOf(
                 "{genDate}" to genDate,
                 "{messageId}" to uuid,
-                "{herId}" to ADRESSEREGISTERET_HELSEOPPLYSNINGER_TEST1_HERID,
+                "{senderHerId}" to FAGSYSTEM_HERID,
+                "{receiverHerId}" to EPJ_HERID,
                 "{patientName}" to name,
                 "{message}" to message
             )
@@ -40,13 +42,15 @@ class DialogMessageProcessorSpec : StringSpec(
 
             replacedXml shouldNotContain "{genDate}"
             replacedXml shouldNotContain "{messageId}"
-            replacedXml shouldNotContain "{herId}"
+            replacedXml shouldNotContain "{senderHerId}"
+            replacedXml shouldNotContain "{receiverHerId}"
             replacedXml shouldNotContain "{patientName}"
             replacedXml shouldNotContain "{message}"
 
             replacedXml shouldContain "<GenDate>$genDate</GenDate>"
             replacedXml shouldContain "<MsgId>$uuid</MsgId>"
-            replacedXml shouldContain "<Id>$ADRESSEREGISTERET_HELSEOPPLYSNINGER_TEST1_HERID</Id>"
+            replacedXml shouldContain "<Id>$FAGSYSTEM_HERID</Id>"
+            replacedXml shouldContain "<Id>$EPJ_HERID</Id>"
             replacedXml shouldContain "<GivenName>$name</GivenName>"
             replacedXml shouldContain "<Sporsmal>$message</Sporsmal>"
         }


### PR DESCRIPTION
Ifm. testing av flyt mot nhn kom det opp at det er nødvendig å sette apprec til lest. Det kan fort bli litt styrete når avsender og mottaker er den samme. Vi ble anbefalt å benytte to herId'er til dette formålet pga. det er litt mer oversiktlig og vi slipper å filtrere på om noe er en melding eller apprec. 

Det kommer en PR på håndtering av dette i epj-simulator.