### PR TITLE
Add the possibility of publishing the same dialog message twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ the following files:
 - `messages.txt`
 - `names.txt`
 
+## Types of dialog messages published
+
+To determine what kind of dialog message is published, a random number between 1 and 11 is generated which then 
+corresponds to one the following messages:
+
+| Outcome                               | Trigger condition  | Description                                              |
+|---------------------------------------|--------------------|----------------------------------------------------------|
+| Single valid dialog message           | number between 1–9 | A valid message                                          |
+| Single invalid dialog message         | number = 10        | Invalid **record key**: (`null`, `""`, or `"1234-abcd"`) |
+| Two valid dialog messages (duplicate) | number = 11        | Same **record key** used twice                           |
+
 ## Dialog message documentation
 
 Documentation for initial request and follow-up request can be found [here](https://sarepta.helsedir.no/standard/Dialogmelding/1.0;profile=1). 

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessor.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessor.kt
@@ -3,7 +3,7 @@ package no.nav.helsemelding.messagegenerator.processor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -45,16 +45,18 @@ class DialogMessageProcessor(
             "{message}" to messages.random()
         )
         val xml = replaceInTemplate(template, params)
-        return flowOf(nextDialogMessage(xml, (1..10).random()))
+        return nextDialogMessage(xml, (1..11).random()).asFlow()
     }
 
     private suspend fun publishDialogMessage(dialogMessage: DialogMessage): Result<RecordMetadata> =
         messagePublisher.publish(dialogMessage.id, dialogMessage.xml)
 }
 
-internal fun nextDialogMessage(xml: String, number: Int): DialogMessage {
+internal fun nextDialogMessage(xml: String, number: Int): List<DialogMessage> {
+    val uuid = Uuid.random()
     return when (number) {
-        in 1..9 -> ValidDialogMessage(Uuid.random(), xml)
-        else -> InvalidDialogMessage(invalidRecordKeys.random(), xml)
+        in 1..9 -> listOf(ValidDialogMessage(uuid, xml))
+        10 -> listOf(InvalidDialogMessage(invalidRecordKeys.random(), xml))
+        else -> List(2) { ValidDialogMessage(uuid, xml) }
     }
 }

--- a/src/test/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessorSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/messagegenerator/processor/DialogMessageProcessorSpec.kt
@@ -2,7 +2,10 @@ package no.nav.helsemelding.messagegenerator.processor
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
+import io.kotest.inspectors.forSingle
 import io.kotest.matchers.collections.shouldBeOneOf
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualUsingFields
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -60,13 +63,25 @@ class DialogMessageProcessorSpec : StringSpec(
 
         "Number 1 through 9 should create a valid dialog message" {
             (1..9).toList().forAll { number ->
-                nextDialogMessage(xml, number).shouldBeInstanceOf<ValidDialogMessage>()
+                nextDialogMessage(xml, number).forSingle { dialogMessage ->
+                    dialogMessage.shouldBeInstanceOf<ValidDialogMessage>()
+                }
             }
         }
 
         "Number 10 should create an invalid dialog message" {
-            val invalidDialogMessage = nextDialogMessage(xml, 10).shouldBeInstanceOf<InvalidDialogMessage>()
-            invalidDialogMessage.id.shouldBeOneOf(null, "", "1234-abcd")
+            nextDialogMessage(xml, 10).forSingle { invalidDialogMessage ->
+                invalidDialogMessage.shouldBeInstanceOf<InvalidDialogMessage>()
+                invalidDialogMessage.id.shouldBeOneOf(null, "", "1234-abcd")
+            }
+        }
+
+        "Number 11 should create two dialog messages with the same uuid" {
+            val dialogMessages = nextDialogMessage(xml, 11).shouldHaveSize(2)
+
+            val firstMessage = dialogMessages.elementAt(0).shouldBeInstanceOf<ValidDialogMessage>()
+            val secondMessage = dialogMessages.elementAt(1).shouldBeInstanceOf<ValidDialogMessage>()
+            firstMessage shouldBeEqualUsingFields secondMessage
         }
     }
 )


### PR DESCRIPTION
Lagt til case hvor samme melding (lik uuid) publiseres to ganger på topic. Tenkte det ga mening å hekte det på eksisterende opplegg så det betyr at 1 av 11 meldinger kan være duplikat. La også til noe dokumentasjon siden den sender litt mer enn bare en type melding.

Issue: https://github.com/navikt/helsemelding-message-generator/issues/11

Gjenstår:
- [x] Avvente merge til https://github.com/navikt/helsemelding-outbound-message-service/pull/80 er merget inn