### PR TITLE
#5 REST-ruter for å stoppe, starte og endre intervall

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,96 @@ to use `FakeDialogMessagePublisher` instead:
 ```kotlin
 val dialogMessageProcessor = DialogMessageProcessor(FakeDialogMessagePublisher())
 ```
+
+## Dynamic scheduler configuration 
+
+The service exposes endpoints for dynamic configuration of the scheduler:
+
+#### Get scheduler status
+
+`GET /scheduler/status`
+
+Returns the current state of all schedulers.
+
+Example request:
+```
+curl https://<host>/scheduler/status
+```
+
+Example response:
+```
+{
+    "dialogMessages": {
+        "enabled": true,
+        "interval": "PT3M",
+        "lastRunAt": "2026-04-24T10:15:00Z"
+    },
+    "incomingMessages": {
+        "enabled": true,
+        "interval": "PT4M",
+        "lastRunAt": "2026-04-24T10:14:30Z"
+    }
+}
+```
+
+#### Stop dialog message scheduler
+
+`POST /scheduler/dialog-messages/stop`
+
+Disables generation of dialog messages.
+
+```
+curl -X POST https://<host>/scheduler/dialog-messages/stop
+```
+
+#### Start dialog message scheduler
+
+`POST /scheduler/dialog-messages/start`
+
+Enables generation of dialog messages.
+
+```
+curl -X POST https://<host>/scheduler/dialog-messages/start
+```
+
+#### Update dialog message interval
+
+`POST /scheduler/dialog-messages/interval/{seconds}`
+
+Updates the interval between generations of dialog messages. 
+`{seconds}` must be a positive integer
+
+```
+curl -X POST https://<host>/scheduler/dialog-messages/interval/300
+```
+
+#### Stop incoming message scheduler
+
+`POST /scheduler/incoming-messages/stop`
+
+Disables generation of incoming messages.
+
+```
+curl -X POST https://<host>/scheduler/incoming-messages/stop
+```
+
+#### Start incoming message scheduler
+
+`POST /scheduler/incoming-messages/start`
+
+Enables generation of incoming messages.
+
+```
+curl -X POST https://<host>/scheduler/incoming-messages/start
+```
+
+#### Update incoming message interval
+
+`POST /scheduler/incoming-messages/interval/{seconds}`
+
+Updates the interval between generations of incoming messages. 
+`{seconds}` must be a positive integer
+
+```
+curl -X POST https://<host>/scheduler/incoming-messages/interval/30
+```

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/App.kt
@@ -14,12 +14,12 @@ import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.launch
 import no.nav.helsemelding.messagegenerator.plugin.configureMetrics
 import no.nav.helsemelding.messagegenerator.plugin.configureRoutes
 import no.nav.helsemelding.messagegenerator.processor.DialogMessageProcessor
 import no.nav.helsemelding.messagegenerator.processor.IncomingMessageProducer
 import no.nav.helsemelding.messagegenerator.publisher.DialogMessagePublisher
+import no.nav.helsemelding.messagegenerator.scheduler.SchedulerService
 import no.nav.helsemelding.messagegenerator.util.coroutineScope
 
 private val log = KotlinLogging.logger {}
@@ -35,20 +35,25 @@ fun main() = SuspendApp {
 
             val incomingMessageProducer = IncomingMessageProducer(deps.ediAdapterClient)
 
+            val schedulerService = SchedulerService(
+                scope = scope,
+                config = config(),
+                dialogMessageProcessor = dialogMessageProcessor,
+                incomingMessageProducer = incomingMessageProducer
+            )
+
             server(
                 Netty,
                 port = config().server.port.value,
                 preWait = config().server.preWait,
-                module = messageGeneratorModule(deps.meterRegistry, dialogMessageProcessor)
+                module = messageGeneratorModule(
+                    deps.meterRegistry,
+                    dialogMessageProcessor,
+                    schedulerService
+                )
             )
 
-            scope.launch {
-                scheduleProcessDialogMessages(dialogMessageProcessor)
-            }
-
-            scope.launch {
-                scheduleGeneratingIncomingMessages(incomingMessageProducer)
-            }
+            schedulerService.init()
 
             awaitCancellation()
         }
@@ -58,11 +63,12 @@ fun main() = SuspendApp {
 
 internal fun messageGeneratorModule(
     meterRegistry: PrometheusMeterRegistry,
-    dialogMessageProcessor: DialogMessageProcessor
+    dialogMessageProcessor: DialogMessageProcessor,
+    schedulerService: SchedulerService
 ): Application.() -> Unit {
     return {
         configureMetrics(meterRegistry)
-        configureRoutes(meterRegistry, dialogMessageProcessor)
+        configureRoutes(meterRegistry, dialogMessageProcessor, schedulerService)
     }
 }
 

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/App.kt
@@ -14,6 +14,7 @@ import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.currentCoroutineContext
+import no.nav.helsemelding.messagegenerator.plugin.configureContentNegotiation
 import no.nav.helsemelding.messagegenerator.plugin.configureMetrics
 import no.nav.helsemelding.messagegenerator.plugin.configureRoutes
 import no.nav.helsemelding.messagegenerator.processor.DialogMessageProcessor
@@ -68,6 +69,7 @@ internal fun messageGeneratorModule(
 ): Application.() -> Unit {
     return {
         configureMetrics(meterRegistry)
+        configureContentNegotiation()
         configureRoutes(meterRegistry, dialogMessageProcessor, schedulerService)
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/model/SchedulerStatus.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/model/SchedulerStatus.kt
@@ -2,7 +2,9 @@ package no.nav.helsemelding.messagegenerator.model
 
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class SchedulerStatus(
     val enabled: Boolean,
     val interval: Duration,

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/model/SchedulerStatus.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/model/SchedulerStatus.kt
@@ -1,0 +1,10 @@
+package no.nav.helsemelding.messagegenerator.model
+
+import kotlinx.datetime.Instant
+import kotlin.time.Duration
+
+data class SchedulerStatus(
+    val enabled: Boolean,
+    val interval: Duration,
+    val lastRunAt: Instant? = null
+)

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/model/SchedulerStatus.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/model/SchedulerStatus.kt
@@ -1,8 +1,8 @@
 package no.nav.helsemelding.messagegenerator.model
 
 import kotlinx.datetime.Instant
-import kotlin.time.Duration
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 @Serializable
 data class SchedulerStatus(

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/ContentNegotiation.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/ContentNegotiation.kt
@@ -1,0 +1,12 @@
+package no.nav.helsemelding.messagegenerator.plugin
+
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+
+fun Application.configureContentNegotiation() {
+    install(ContentNegotiation) {
+        json()
+    }
+}

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/Routes.kt
@@ -1,6 +1,7 @@
 package no.nav.helsemelding.messagegenerator.plugin
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
@@ -94,7 +95,7 @@ fun Route.externalRoutes(
             post("/interval/{intervalSeconds}") {
                 val intervalSeconds = call.parameters["intervalSeconds"]?.toLongOrNull()
                 if (intervalSeconds == null || intervalSeconds <= 0) {
-                    call.respondText("Invalid interval. Please provide a positive number of seconds.")
+                    call.respondText("Invalid interval. Please provide a positive number of seconds.", status = HttpStatusCode.BadRequest)
                     return@post
                 }
 
@@ -118,7 +119,7 @@ fun Route.externalRoutes(
             post("/interval/{intervalSeconds}") {
                 val intervalSeconds = call.parameters["intervalSeconds"]?.toLongOrNull()
                 if (intervalSeconds == null || intervalSeconds <= 0) {
-                    call.respondText("Invalid interval. Please provide a positive number of seconds.")
+                    call.respondText("Invalid interval. Please provide a positive number of seconds.", status = HttpStatusCode.BadRequest)
                     return@post
                 }
 

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/Routes.kt
@@ -5,20 +5,24 @@ import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import no.nav.helsemelding.messagegenerator.processor.DialogMessageProcessor
+import no.nav.helsemelding.messagegenerator.scheduler.SchedulerService
+import kotlin.time.Duration.Companion.seconds
 
 fun Application.configureRoutes(
     registry: PrometheusMeterRegistry,
-    dialogMessageProcessor: DialogMessageProcessor
+    dialogMessageProcessor: DialogMessageProcessor,
+    schedulerService: SchedulerService
 ) {
     routing {
         internalRoutes(registry)
-        externalRoutes(dialogMessageProcessor)
+        externalRoutes(dialogMessageProcessor, schedulerService)
     }
 }
 
@@ -36,7 +40,10 @@ fun Route.internalRoutes(registry: PrometheusMeterRegistry) {
     }
 }
 
-fun Route.externalRoutes(dialogMessageProcessor: DialogMessageProcessor) {
+fun Route.externalRoutes(
+    dialogMessageProcessor: DialogMessageProcessor,
+    schedulerService: SchedulerService
+) {
     get("/generate-messages") {
         var count = call.request.queryParameters["count"]?.toIntOrNull() ?: 1
         if (count > 100) count = 100
@@ -51,5 +58,66 @@ fun Route.externalRoutes(dialogMessageProcessor: DialogMessageProcessor) {
         }
 
         call.respondText("Published $published dialog messages.")
+    }
+
+    route("/scheduler") {
+        get("/status") {
+            val dialogStatus = schedulerService.dialogMessages.status()
+            val incomingStatus = schedulerService.incomingMessages.status()
+            call.respond(
+                mapOf(
+                    "dialogMessages" to dialogStatus,
+                    "incomingMessages" to incomingStatus
+                )
+            )
+        }
+
+        route("/dialog-messages") {
+            post("/start") {
+                schedulerService.dialogMessages.start()
+                call.respondText("Dialog messages scheduler started.")
+            }
+
+            post("/stop") {
+                schedulerService.dialogMessages.stop()
+                call.respondText("Dialog messages scheduler stopped.")
+            }
+
+            post("/interval/{intervalSeconds}") {
+                val intervalSeconds = call.parameters["intervalSeconds"]?.toLongOrNull()
+                if (intervalSeconds == null || intervalSeconds <= 0) {
+                    call.respondText("Invalid interval. Please provide a positive number of seconds.")
+                    return@post
+                }
+
+                schedulerService.dialogMessages.updateInterval(intervalSeconds.seconds)
+
+                call.respondText("Dialog messages scheduler interval updated to $intervalSeconds seconds.")
+            }
+        }
+
+        route("/incoming-messages") {
+            post("/start") {
+                schedulerService.incomingMessages.start()
+                call.respondText("Incoming messages scheduler started.")
+            }
+
+            post("/stop") {
+                schedulerService.incomingMessages.stop()
+                call.respondText("Incoming messages scheduler stopped.")
+            }
+
+            post("/interval/{intervalSeconds}") {
+                val intervalSeconds = call.parameters["intervalSeconds"]?.toLongOrNull()
+                if (intervalSeconds == null || intervalSeconds <= 0) {
+                    call.respondText("Invalid interval. Please provide a positive number of seconds.")
+                    return@post
+                }
+
+                schedulerService.incomingMessages.updateInterval(intervalSeconds.seconds)
+
+                call.respondText("Incoming messages scheduler interval updated to $intervalSeconds seconds.")
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/plugin/Routes.kt
@@ -1,5 +1,6 @@
 package no.nav.helsemelding.messagegenerator.plugin
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.Application
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
@@ -14,6 +15,8 @@ import kotlinx.coroutines.delay
 import no.nav.helsemelding.messagegenerator.processor.DialogMessageProcessor
 import no.nav.helsemelding.messagegenerator.scheduler.SchedulerService
 import kotlin.time.Duration.Companion.seconds
+
+private val log = KotlinLogging.logger {}
 
 fun Application.configureRoutes(
     registry: PrometheusMeterRegistry,
@@ -62,14 +65,19 @@ fun Route.externalRoutes(
 
     route("/scheduler") {
         get("/status") {
-            val dialogStatus = schedulerService.dialogMessages.status()
-            val incomingStatus = schedulerService.incomingMessages.status()
-            call.respond(
-                mapOf(
-                    "dialogMessages" to dialogStatus,
-                    "incomingMessages" to incomingStatus
+            try {
+                val dialogStatus = schedulerService.dialogMessages.status()
+                val incomingStatus = schedulerService.incomingMessages.status()
+                call.respond(
+                    mapOf(
+                        "dialogMessages" to dialogStatus,
+                        "incomingMessages" to incomingStatus
+                    )
                 )
-            )
+            } catch (e: Exception) {
+                log.error(e) { "Failed to get scheduler status" }
+                throw e
+            }
         }
 
         route("/dialog-messages") {

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/scheduler/ManagedScheduler.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/scheduler/ManagedScheduler.kt
@@ -46,9 +46,8 @@ class ManagedScheduler(
                     mutex.withLock {
                         lastRunAt = Clock.System.now()
                     }
-                } catch (e: CancellationException) {
-                    throw e
                 } catch (e: Throwable) {
+                    if (e is CancellationException) throw e
                     log.error(e) { "Scheduled action failed for '$name'" }
                 }
 

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/scheduler/ManagedScheduler.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/scheduler/ManagedScheduler.kt
@@ -1,0 +1,84 @@
+package no.nav.helsemelding.messagegenerator.scheduler
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import no.nav.helsemelding.messagegenerator.model.SchedulerStatus
+import kotlin.time.Duration
+
+private val log = KotlinLogging.logger {}
+
+class ManagedScheduler(
+    private val name: String,
+    initialEnabled: Boolean,
+    initialInterval: Duration,
+    private val scope: CoroutineScope,
+    private val action: suspend () -> Unit
+) {
+    private val mutex = Mutex()
+
+    private var enabled: Boolean = initialEnabled
+    private var interval: Duration = initialInterval
+    private var lastRunAt: Instant? = null
+    private var job: Job? = null
+
+    suspend fun init() {
+        if (enabled) start()
+    }
+
+    suspend fun start() = mutex.withLock {
+        enabled = true
+        if (job?.isActive == true) return
+
+        job = scope.launch {
+            log.info { "Starting scheduler '$name' with interval=$interval" }
+            while (isActive) {
+                try {
+                    action()
+                    mutex.withLock {
+                        lastRunAt = Clock.System.now()
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    log.error(e) { "Scheduled action failed for '$name'" }
+                }
+
+                val currentInterval = mutex.withLock { interval }
+                delay(currentInterval)
+            }
+        }
+    }
+
+    suspend fun stop() = mutex.withLock {
+        enabled = false
+        job?.cancel()
+        job = null
+        log.info { "Stopped scheduler '$name'" }
+    }
+
+    suspend fun updateInterval(newInterval: Duration) {
+        stop()
+        mutex.withLock {
+            interval = newInterval
+            log.info { "Updated scheduler '$name' interval to $newInterval" }
+        }
+        start()
+    }
+
+    suspend fun status(): SchedulerStatus = mutex.withLock {
+        SchedulerStatus(
+            enabled = enabled,
+            interval = interval,
+            lastRunAt = lastRunAt
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/helsemelding/messagegenerator/scheduler/SchedulerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/messagegenerator/scheduler/SchedulerService.kt
@@ -1,0 +1,38 @@
+package no.nav.helsemelding.messagegenerator.scheduler
+
+import kotlinx.coroutines.CoroutineScope
+import no.nav.helsemelding.messagegenerator.config.Config
+import no.nav.helsemelding.messagegenerator.processor.DialogMessageProcessor
+import no.nav.helsemelding.messagegenerator.processor.IncomingMessageProducer
+
+class SchedulerService(
+    scope: CoroutineScope,
+    config: Config,
+    dialogMessageProcessor: DialogMessageProcessor,
+    incomingMessageProducer: IncomingMessageProducer
+) {
+    val dialogMessages = ManagedScheduler(
+        name = "dialog-messages",
+        initialEnabled = config.kafka.topics.dialogMessage.enabled,
+        initialInterval = config.kafka.topics.dialogMessage.interval,
+        scope = scope,
+        action = {
+            dialogMessageProcessor.processMessages(scope)
+        }
+    )
+
+    val incomingMessages = ManagedScheduler(
+        name = "incoming-messages",
+        initialEnabled = config.incomingMessages.enabled,
+        initialInterval = config.incomingMessages.interval,
+        scope = scope,
+        action = {
+            incomingMessageProducer.produceIncomingMessage()
+        }
+    )
+
+    suspend fun init() {
+        dialogMessages.init()
+        incomingMessages.init()
+    }
+}

--- a/src/test/kotlin/no/nav/helsemelding/messagegenerator/plugin/RoutesSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/messagegenerator/plugin/RoutesSpec.kt
@@ -2,8 +2,8 @@ package no.nav.helsemelding.messagegenerator.plugin
 
 import com.sksamuel.hoplite.Masked
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -49,13 +49,15 @@ class RoutesSpec : StringSpec({
 
             val statusResponse = response.body<Map<String, SchedulerStatus>>()
 
-            statusResponse["dialogMessages"] shouldNotBe null
-            statusResponse["dialogMessages"]?.enabled shouldBe true
-            statusResponse["dialogMessages"]?.interval shouldBe 3.minutes
+            val dialogMessageScheduler = statusResponse["dialogMessages"]
+            dialogMessageScheduler.shouldNotBeNull()
+            dialogMessageScheduler.enabled shouldBe true
+            dialogMessageScheduler.interval shouldBe 3.minutes
 
-            statusResponse["incomingMessages"] shouldNotBe null
-            statusResponse["incomingMessages"]?.enabled shouldBe true
-            statusResponse["incomingMessages"]?.interval shouldBe 4.minutes
+            val incomingMessagesScheduler = statusResponse["incomingMessages"]
+            incomingMessagesScheduler.shouldNotBeNull()
+            incomingMessagesScheduler.enabled shouldBe true
+            incomingMessagesScheduler.interval shouldBe 4.minutes
         }
     }
 
@@ -76,8 +78,10 @@ class RoutesSpec : StringSpec({
                 response.status shouldBe HttpStatusCode.OK
 
                 val statusResponse = response.body<Map<String, SchedulerStatus>>()
-                statusResponse[schedulerKey] shouldNotBe null
-                statusResponse[schedulerKey]?.enabled shouldBe false
+
+                val scheduler = statusResponse[schedulerKey]
+                scheduler.shouldNotBeNull()
+                scheduler.enabled shouldBe false
             }
         }
     }
@@ -99,8 +103,10 @@ class RoutesSpec : StringSpec({
                 response.status shouldBe HttpStatusCode.OK
 
                 val statusResponse = response.body<Map<String, SchedulerStatus>>()
-                statusResponse[schedulerKey] shouldNotBe null
-                statusResponse[schedulerKey]?.enabled shouldBe true
+
+                val scheduler = statusResponse[schedulerKey]
+                scheduler.shouldNotBeNull()
+                scheduler.enabled shouldBe true
             }
         }
     }
@@ -120,9 +126,11 @@ class RoutesSpec : StringSpec({
                 }
 
                 val statusResponse = response.body<Map<String, SchedulerStatus>>()
-                statusResponse[schedulerKey] shouldNotBe null
-                statusResponse[schedulerKey]?.enabled shouldBe true
-                statusResponse[schedulerKey]?.interval shouldBe 10.minutes
+
+                val scheduler = statusResponse[schedulerKey]
+                scheduler.shouldNotBeNull()
+                scheduler.enabled shouldBe true
+                scheduler.interval shouldBe 10.minutes
             }
         }
     }

--- a/src/test/kotlin/no/nav/helsemelding/messagegenerator/plugin/RoutesSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/messagegenerator/plugin/RoutesSpec.kt
@@ -2,7 +2,6 @@ package no.nav.helsemelding.messagegenerator.plugin
 
 import com.sksamuel.hoplite.Masked
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.ktor.client.HttpClient
@@ -60,91 +59,89 @@ class RoutesSpec : StringSpec({
         }
     }
 
-    // /scheduler/dialog-messages/stop endpoint disables scheduler
-    // /scheduler/incoming-messages/stop endpoint disables scheduler
-    withData(
-        nameFn = { (stopEndpoint) -> "$stopEndpoint endpoint disables scheduler" },
-        listOf(
-            listOf("/scheduler/dialog-messages/stop", "dialogMessages"),
-            listOf("/scheduler/incoming-messages/stop", "incomingMessages")
-        )
-    ) { (stopEndpoint, schedulerKey) ->
+    "/stop endpoints disable schedulers" {
         routesTestApplication { client ->
-            client.post(stopEndpoint)
+            val testCases = listOf(
+                listOf("/scheduler/dialog-messages/stop", "dialogMessages"),
+                listOf("/scheduler/incoming-messages/stop", "incomingMessages")
+            )
 
-            val response = client.get("/scheduler/status") {
-                accept(ContentType.Application.Json)
+            testCases.forEach { (stopEndpoint, schedulerKey) ->
+                client.post(stopEndpoint)
+
+                val response = client.get("/scheduler/status") {
+                    accept(ContentType.Application.Json)
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+
+                val statusResponse = response.body<Map<String, SchedulerStatus>>()
+                statusResponse[schedulerKey] shouldNotBe null
+                statusResponse[schedulerKey]?.enabled shouldBe false
             }
-
-            response.status shouldBe HttpStatusCode.OK
-
-            val statusResponse = response.body<Map<String, SchedulerStatus>>()
-            statusResponse[schedulerKey] shouldNotBe null
-            statusResponse[schedulerKey]?.enabled shouldBe false
         }
     }
 
-    // /scheduler/dialog-messages/start endpoint enables scheduler
-    // /scheduler/incoming-messages/start endpoint enables scheduler
-    withData(
-        nameFn = { (startEndpoint) -> "$startEndpoint endpoint enables scheduler" },
-        listOf(
-            listOf("/scheduler/dialog-messages/start", "dialogMessages"),
-            listOf("/scheduler/incoming-messages/start", "incomingMessages")
-        )
-    ) { (startEndpoint, schedulerKey) ->
+    "/start endpoints enable schedulers" {
         routesTestApplication(enableSchedulers = false) { client ->
-            client.post(startEndpoint)
+            val testCases = listOf(
+                listOf("/scheduler/dialog-messages/start", "dialogMessages"),
+                listOf("/scheduler/incoming-messages/start", "incomingMessages")
+            )
 
-            val response = client.get("/scheduler/status") {
-                accept(ContentType.Application.Json)
+            testCases.forEach { (startEndpoint, schedulerKey) ->
+                client.post(startEndpoint)
+
+                val response = client.get("/scheduler/status") {
+                    accept(ContentType.Application.Json)
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+
+                val statusResponse = response.body<Map<String, SchedulerStatus>>()
+                statusResponse[schedulerKey] shouldNotBe null
+                statusResponse[schedulerKey]?.enabled shouldBe true
             }
-
-            response.status shouldBe HttpStatusCode.OK
-
-            val statusResponse = response.body<Map<String, SchedulerStatus>>()
-            statusResponse[schedulerKey] shouldNotBe null
-            statusResponse[schedulerKey]?.enabled shouldBe true
         }
     }
 
-    // /scheduler/dialog-messages/interval endpoint changes interval for scheduler
-    // /scheduler/incoming-messages/interval endpoint changes interval for scheduler
-    withData(
-        nameFn = { (intervalEndpoint) -> "$intervalEndpoint endpoint changes interval for scheduler" },
-        listOf(
-            listOf("/scheduler/dialog-messages/interval", "dialogMessages"),
-            listOf("/scheduler/incoming-messages/interval", "incomingMessages")
-        )
-    ) { (intervalEndpoint, schedulerKey) ->
-        routesTestApplication(enableSchedulers = false) { client ->
-            client.post("$intervalEndpoint/600")
+    "/interval/{intervalSeconds} endpoint changes interval for scheduler" {
+        routesTestApplication { client ->
+            val testCases = listOf(
+                listOf("/scheduler/dialog-messages/interval", "dialogMessages"),
+                listOf("/scheduler/incoming-messages/interval", "incomingMessages")
+            )
 
-            val response = client.get("/scheduler/status") {
-                accept(ContentType.Application.Json)
+            testCases.forEach { (intervalEndpoint, schedulerKey) ->
+                client.post("$intervalEndpoint/600")
+
+                val response = client.get("/scheduler/status") {
+                    accept(ContentType.Application.Json)
+                }
+
+                val statusResponse = response.body<Map<String, SchedulerStatus>>()
+                statusResponse[schedulerKey] shouldNotBe null
+                statusResponse[schedulerKey]?.enabled shouldBe true
+                statusResponse[schedulerKey]?.interval shouldBe 10.minutes
             }
-
-            val statusResponse = response.body<Map<String, SchedulerStatus>>()
-            statusResponse[schedulerKey] shouldNotBe null
-            statusResponse[schedulerKey]?.enabled shouldBe true
-            statusResponse[schedulerKey]?.interval shouldBe 10.minutes
         }
     }
 
-    // /scheduler/dialog-messages/interval endpoint rejects non-positive values
-    // /scheduler/incoming-messages/interval endpoint rejects non-positive values
-    withData(
-        nameFn = { (intervalEndpoint) -> "$intervalEndpoint endpoint rejects non-positive values" },
-        listOf(
-            listOf("/scheduler/dialog-messages/interval"),
-            listOf("/scheduler/incoming-messages/interval")
-        )
-    ) { (intervalEndpoint) ->
-        routesTestApplication(enableSchedulers = false) { client ->
-            val response = client.post("$intervalEndpoint/0")
+    "/interval/{intervalSeconds} endpoint rejects non-positive values" {
+        routesTestApplication { client ->
+            val testCases = listOf(
+                listOf("/scheduler/dialog-messages/interval", 0),
+                listOf("/scheduler/dialog-messages/interval", -60),
+                listOf("/scheduler/incoming-messages/interval", 0),
+                listOf("/scheduler/incoming-messages/interval", -60)
+            )
 
-            response.status shouldBe HttpStatusCode.BadRequest
-            response.bodyAsText() shouldBe "Invalid interval. Please provide a positive number of seconds."
+            testCases.forEach { (intervalEndpoint, intervalSeconds) ->
+                val response = client.post("$intervalEndpoint/$intervalSeconds")
+
+                response.status shouldBe HttpStatusCode.BadRequest
+                response.bodyAsText() shouldBe "Invalid interval. Please provide a positive number of seconds."
+            }
         }
     }
 })

--- a/src/test/kotlin/no/nav/helsemelding/messagegenerator/plugin/RoutesSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/messagegenerator/plugin/RoutesSpec.kt
@@ -1,0 +1,215 @@
+package no.nav.helsemelding.messagegenerator.plugin
+
+import com.sksamuel.hoplite.Masked
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import no.nav.helsemelding.messagegenerator.config.Config
+import no.nav.helsemelding.messagegenerator.config.DialogMessage
+import no.nav.helsemelding.messagegenerator.config.EdiAdapter
+import no.nav.helsemelding.messagegenerator.config.IncomingMessages
+import no.nav.helsemelding.messagegenerator.config.Kafka
+import no.nav.helsemelding.messagegenerator.config.Port
+import no.nav.helsemelding.messagegenerator.config.Scope
+import no.nav.helsemelding.messagegenerator.config.Server
+import no.nav.helsemelding.messagegenerator.config.Topics
+import no.nav.helsemelding.messagegenerator.model.SchedulerStatus
+import no.nav.helsemelding.messagegenerator.processor.DialogMessageProcessor
+import no.nav.helsemelding.messagegenerator.processor.FakeEdiAdapterClient
+import no.nav.helsemelding.messagegenerator.processor.IncomingMessageProducer
+import no.nav.helsemelding.messagegenerator.publisher.FakeDialogMessagePublisher
+import no.nav.helsemelding.messagegenerator.scheduler.SchedulerService
+import kotlin.time.Duration.Companion.minutes
+
+class RoutesSpec : StringSpec({
+    "/scheduler/status endpoint returns json payload" {
+        routesTestApplication { client ->
+            val response = client.get("/scheduler/status") {
+                accept(ContentType.Application.Json)
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+
+            val statusResponse = response.body<Map<String, SchedulerStatus>>()
+
+            statusResponse["dialogMessages"] shouldNotBe null
+            statusResponse["dialogMessages"]?.enabled shouldBe true
+            statusResponse["dialogMessages"]?.interval shouldBe 3.minutes
+
+            statusResponse["incomingMessages"] shouldNotBe null
+            statusResponse["incomingMessages"]?.enabled shouldBe true
+            statusResponse["incomingMessages"]?.interval shouldBe 4.minutes
+        }
+    }
+
+    // /scheduler/dialog-messages/stop endpoint disables scheduler
+    // /scheduler/incoming-messages/stop endpoint disables scheduler
+    withData(
+        nameFn = { (stopEndpoint) -> "$stopEndpoint endpoint disables scheduler" },
+        listOf(
+            listOf("/scheduler/dialog-messages/stop", "dialogMessages"),
+            listOf("/scheduler/incoming-messages/stop", "incomingMessages")
+        )
+    ) { (stopEndpoint, schedulerKey) ->
+        routesTestApplication { client ->
+            client.post(stopEndpoint)
+
+            val response = client.get("/scheduler/status") {
+                accept(ContentType.Application.Json)
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+
+            val statusResponse = response.body<Map<String, SchedulerStatus>>()
+            statusResponse[schedulerKey] shouldNotBe null
+            statusResponse[schedulerKey]?.enabled shouldBe false
+        }
+    }
+
+    // /scheduler/dialog-messages/start endpoint enables scheduler
+    // /scheduler/incoming-messages/start endpoint enables scheduler
+    withData(
+        nameFn = { (startEndpoint) -> "$startEndpoint endpoint enables scheduler" },
+        listOf(
+            listOf("/scheduler/dialog-messages/start", "dialogMessages"),
+            listOf("/scheduler/incoming-messages/start", "incomingMessages")
+        )
+    ) { (startEndpoint, schedulerKey) ->
+        routesTestApplication(enableSchedulers = false) { client ->
+            client.post(startEndpoint)
+
+            val response = client.get("/scheduler/status") {
+                accept(ContentType.Application.Json)
+            }
+
+            response.status shouldBe HttpStatusCode.OK
+
+            val statusResponse = response.body<Map<String, SchedulerStatus>>()
+            statusResponse[schedulerKey] shouldNotBe null
+            statusResponse[schedulerKey]?.enabled shouldBe true
+        }
+    }
+
+    // /scheduler/dialog-messages/interval endpoint changes interval for scheduler
+    // /scheduler/incoming-messages/interval endpoint changes interval for scheduler
+    withData(
+        nameFn = { (intervalEndpoint) -> "$intervalEndpoint endpoint changes interval for scheduler" },
+        listOf(
+            listOf("/scheduler/dialog-messages/interval", "dialogMessages"),
+            listOf("/scheduler/incoming-messages/interval", "incomingMessages")
+        )
+    ) { (intervalEndpoint, schedulerKey) ->
+        routesTestApplication(enableSchedulers = false) { client ->
+            client.post("$intervalEndpoint/600")
+
+            val response = client.get("/scheduler/status") {
+                accept(ContentType.Application.Json)
+            }
+
+            val statusResponse = response.body<Map<String, SchedulerStatus>>()
+            statusResponse[schedulerKey] shouldNotBe null
+            statusResponse[schedulerKey]?.enabled shouldBe true
+            statusResponse[schedulerKey]?.interval shouldBe 10.minutes
+        }
+    }
+
+    // /scheduler/dialog-messages/interval endpoint rejects non-positive values
+    // /scheduler/incoming-messages/interval endpoint rejects non-positive values
+    withData(
+        nameFn = { (intervalEndpoint) -> "$intervalEndpoint endpoint rejects non-positive values" },
+        listOf(
+            listOf("/scheduler/dialog-messages/interval"),
+            listOf("/scheduler/incoming-messages/interval")
+        )
+    ) { (intervalEndpoint) ->
+        routesTestApplication(enableSchedulers = false) { client ->
+            val response = client.post("$intervalEndpoint/0")
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            response.bodyAsText() shouldBe "Invalid interval. Please provide a positive number of seconds."
+        }
+    }
+})
+
+private fun routesTestApplication(
+    enableSchedulers: Boolean = true,
+    testBlock: suspend ApplicationTestBuilder.(client: HttpClient) -> Unit
+) = testApplication {
+    val schedulerService: SchedulerService = testSchedulerService(enableSchedulers)
+    application {
+        configureContentNegotiation()
+        configureRoutes(
+            registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
+            dialogMessageProcessor = DialogMessageProcessor(FakeDialogMessagePublisher()),
+            schedulerService = schedulerService
+        )
+    }
+
+    val client = createClient {
+        install(ContentNegotiation) {
+            json()
+        }
+    }
+
+    testBlock(client)
+}
+
+private fun testSchedulerService(enableSchedulers: Boolean): SchedulerService {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val config = Config(
+        server = Server(Port(8080), 1.minutes),
+        kafka = Kafka(
+            groupId = "test-group",
+            bootstrapServers = "localhost:9092",
+            securityProtocol = Kafka.SecurityProtocol("SSL"),
+            keystoreType = Kafka.KeystoreType("JKS"),
+            keystoreLocation = Kafka.KeystoreLocation("/tmp/keystore.jks"),
+            keystorePassword = Masked("secret"),
+            truststoreType = Kafka.TruststoreType("JKS"),
+            truststoreLocation = Kafka.TruststoreLocation("/tmp/truststore.jks"),
+            truststorePassword = Masked("secret"),
+            topics = Topics(
+                dialogMessage = DialogMessage(
+                    topic = "dialog-topic",
+                    enabled = enableSchedulers,
+                    interval = 3.minutes
+                )
+            )
+        ),
+        ediAdapter = EdiAdapter(Scope("api://test/.default")),
+        incomingMessages = IncomingMessages(
+            enabled = enableSchedulers,
+            interval = 4.minutes
+        )
+    )
+
+    return SchedulerService(
+        scope = scope,
+        config = config,
+        dialogMessageProcessor = DialogMessageProcessor(FakeDialogMessagePublisher()),
+        incomingMessageProducer = IncomingMessageProducer(
+            ediAdapterClient = FakeEdiAdapterClient(),
+            template = "<MsgHead></MsgHead>",
+            names = listOf("Test Person"),
+            messages = listOf("Test message")
+        )
+    )
+}


### PR DESCRIPTION
1. Opprettet `ManagedScheduler` som kan starte og stoppe periodiske operasjoner.
2. Eksponerte endepunkter som gjør det mulig å starte, stoppe og ender frekvens av meldingsgenerering uten omstart av tjenesten.
3. Lagt til tester for endepunktene. 

API-et til ruteren:

- `GET /scheduler/status` - viser nåværende tilstand til meldingsgeneratorer. Tilstanden inneholder felt:
    -  `enabled `- viser om meldingsgenerering er på.
    -  `interval `-  frekvens av meldingsgenereringen.
    -  `lastRunAt `- når en melding av denne typen ble generert siste gang.
For eksempel:
```
{
  "dialogMessages" : {
    "enabled" : true,
    "interval" : "PT3M",
    "lastRunAt" : "2026-04-23T10:22:10.676732691Z"
  },
  "incomingMessages" : {
    "enabled" : true,
    "interval" : "PT4M",
    "lastRunAt" : "2026-04-23T10:25:02.445059650Z"
  }
}
```
- `POST /scheduler/dialog-messages/start` - starter generering av utgående dialogmeldinger (den er startet som standard)
- `POST /scheduler/dialog-messages/stop` - stopper generering av utgående dialogmeldinger.
- `POST /scheduler/dialog-messages/interval/{intervalSeconds}` - endrer frekvens av generering av utgående dialogmeldinger.

- `POST /scheduler/incoming-messages/start` - starter generering av innkommende dialogmeldinger (den er startet som standard)
- `POST /scheduler/incoming-messages/stop` - stopper generering av inknommende dialogmeldinger.
- `POST /scheduler/incoming-messages/interval/{intervalSeconds}` - endrer frekvens av generering av innkommende dialogmeldinger.

Oppgave: https://github.com/navikt/helsemelding-message-generator/issues/5