### PR TITLE
Oppdatert `edi-adapter-client` til v0.0.7

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,7 @@ dependencyResolutionManagement {
             version("prometheus", "1.12.4")
             version("logback", "1.4.11")
             version("logstash", "7.4")
-            version("edi-adapter-client", "0.0.5")
+            version("edi-adapter-client", "0.0.7")
 
             library("arrow-core", "io.arrow-kt", "arrow-core").versionRef("arrow")
             library("arrow-functions", "io.arrow-kt", "arrow-functions").versionRef("arrow")

--- a/src/test/kotlin/no/nav/helsemelding/messagegenerator/processor/IncomingMessageProducerSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/messagegenerator/processor/IncomingMessageProducerSpec.kt
@@ -9,14 +9,18 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import no.nav.helsemelding.ediadapter.client.EdiAdapterClient
+import no.nav.helsemelding.ediadapter.client.ExperimentalEdiAdapterApi
 import no.nav.helsemelding.ediadapter.model.ApprecInfo
 import no.nav.helsemelding.ediadapter.model.ErrorMessage
 import no.nav.helsemelding.ediadapter.model.GetBusinessDocumentResponse
 import no.nav.helsemelding.ediadapter.model.GetMessagesRequest
+import no.nav.helsemelding.ediadapter.model.GetNoticesRequest
 import no.nav.helsemelding.ediadapter.model.Message
 import no.nav.helsemelding.ediadapter.model.Metadata
+import no.nav.helsemelding.ediadapter.model.Notice
 import no.nav.helsemelding.ediadapter.model.PostAppRecRequest
 import no.nav.helsemelding.ediadapter.model.PostMessageRequest
+import no.nav.helsemelding.ediadapter.model.PostMshConfigurationRequest
 import no.nav.helsemelding.ediadapter.model.StatusInfo
 import no.nav.helsemelding.messagegenerator.util.readFileToString
 import java.util.Base64
@@ -163,6 +167,14 @@ class FakeEdiAdapterClient : EdiAdapterClient {
     override suspend fun getApprecInfo(id: Uuid): Either<ErrorMessage, List<ApprecInfo>> = Left(errorMessage404)
 
     override suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Either<ErrorMessage, List<Message>> = Left(errorMessage404)
+
+    @ExperimentalEdiAdapterApi
+    override suspend fun postMshConfiguration(postMshConfigurationRequest: PostMshConfigurationRequest): Either<ErrorMessage, Unit> =
+        Left(errorMessage404)
+
+    @ExperimentalEdiAdapterApi
+    override suspend fun getNotices(getNoticesRequest: GetNoticesRequest): Either<ErrorMessage, List<Notice>> =
+        Left(errorMessage404)
 
     override fun close() {}
 }


### PR DESCRIPTION
`edi-adapter-client` er brukt så mange steder! 🔢 

Oppgave: https://github.com/navikt/helsemelding-outbound-message-service/issues/85